### PR TITLE
Small fixes for Fetch/CacheStorage API gotchas

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -21,8 +21,11 @@ self.addEventListener('fetch', (e) => {
         }
         console.log(e.request.url);
         let resp = await caches.match(e.request);
-        if (!resp)
+        if (!resp) {
+            if (e.request.cache === 'only-if-cached')
+                event.request.mode = 'same-origin';
             resp = await fetch(e.request);
+        }
         return resp;
     })());
 });

--- a/sw.js
+++ b/sw.js
@@ -21,11 +21,8 @@ self.addEventListener('fetch', (e) => {
         }
         console.log(e.request.url);
         let resp = await caches.match(e.request);
-        if (!resp) {
-            if (e.request.cache === 'only-if-cached')
-                event.request.mode = 'same-origin';
+        if (!resp)
             resp = await fetch(e.request);
-        }
         return resp;
     })());
 });


### PR DESCRIPTION
- Response's status must not be null
- Response body must be null for particular status code
- Vary: * cannot be accepted, so ignore the header for now
- Don't add duplicated requests (as a work-around for now)